### PR TITLE
Add two new env vars to configure DB SSL

### DIFF
--- a/.docker.env
+++ b/.docker.env
@@ -17,6 +17,9 @@ DB_NAME=postgres
 DB_USER=
 DB_PASSWORD=
 DB_SSL=false
+# To skip SSL verification when using SSL
+# DB_SSL_SKIP_VERIFY=true
+# define DB_SSL_CERT as multiline string in docker-compose.yml
 
 # Redis host and port
 REDIS_HOST=redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,14 +10,17 @@ services:
     ports:
       - "3000:3000"
     env_file:
-      - .env
+      - .docker.env
     environment:
       DB_HOST: postgres
       DB_NAME: kutt
       DB_USER: user
       DB_PASSWORD: pass
       REDIS_HOST: redis
-
+      # DB_SSL_CERT: |
+      #   -----BEGIN CERTIFICATE-----
+      #   ...
+      #   -----END CERTIFICATE-----
   redis:
     image: redis:6.0-alpine
     volumes:

--- a/server/db-credentials.ts
+++ b/server/db-credentials.ts
@@ -1,12 +1,19 @@
 import env from "./env";
 
+if (env.DB_SSL) {
+  var ssl = { rejectUnauthorized: !env.DB_SSL_SKIP_VERIFY }
+  if (env.DB_SSL_CERT) {
+    ssl['ca'] = env.DB_SSL_CERT
+  }
+}
+
 const credentials = {
   host: env.DB_HOST,
   database: env.DB_NAME,
   user: env.DB_USER,
   port: env.DB_PORT,
   password: env.DB_PASSWORD,
-  ssl: env.DB_SSL
+  ssl: env.DB_SSL ? ssl : false
 } as const;
 
 export default credentials;

--- a/server/env.ts
+++ b/server/env.ts
@@ -14,6 +14,8 @@ const env = cleanEnv(process.env, {
   DB_USER: str(),
   DB_PASSWORD: str(),
   DB_SSL: bool({ default: false }),
+  DB_SSL_SKIP_VERIFY: bool({ default: false }),
+  DB_SSL_CERT: str({ default: "" }),
   DB_POOL_MIN: num({ default: 2 }),
   DB_POOL_MAX: num({ default: 10 }),
   REDIS_HOST: str({ default: "127.0.0.1" }),


### PR DESCRIPTION
This allows more configuration for the database SSL mode using new parameters:
1. `DB_SSL_SKIP_VERIFY`: if set to true, will not verify the server certificate (suitable for self-signed certificates).
2. `DB_SSL_CERT`: The server CA certificate to verify against if it is self-signed.

This results in new scenarios:
1. SSL on but without certificate verification
2. SSL on with certificate verification against a custom CA bundle